### PR TITLE
Fix potential error when multiple AppInstaller versions installed and add explicit machine scope to Test-WinGetApp

### DIFF
--- a/Reset-Appx.ps1
+++ b/Reset-Appx.ps1
@@ -659,12 +659,12 @@ Process {
         )
         try {
             Write-Host "Checking if '$($winGetAppName)' is installed using Id '$($winGetAppId)'..."
-            Write-Host "winget.exe list --id $($winGetAppId) --source $($winGetAppSource) --accept-source-agreements"
+            Write-Host "winget.exe list --id $($winGetAppId) --source $($winGetAppSource) --scope machine --accept-source-agreements"
             Write-LogEntry -logEntry "Checking if '$($winGetAppName)' is installed using Id '$($winGetAppId)'..." -logID $logID
-            Write-LogEntry -logEntry "winget.exe list --id '$($winGetAppId)' --source $($winGetAppSource) --accept-source-agreements" -logID $logID 
+            Write-LogEntry -logEntry "winget.exe list --id '$($winGetAppId)' --source $($winGetAppSource) --scope machine --accept-source-agreements" -logID $logID 
 
             Set-Location $winGetPath
-            $winGetTest = & .\$winGetBinary list --id $winGetAppId --source $winGetAppSource --accept-source-agreements
+            $winGetTest = & .\$winGetBinary list --id $winGetAppId --source $winGetAppSource --scope machine --accept-source-agreements
                 
             foreach ($line in $winGetTest) {
                 

--- a/Reset-Appx.ps1
+++ b/Reset-Appx.ps1
@@ -554,7 +554,8 @@ Process {
         Write-LogEntry -logEntry "Testing the WinGet package and other dependancies are installed" -logID $logID
 
         try {
-            $winGetPath = (Get-AppxPackage -AllUsers | Where-Object { $_.Name -eq $winGetPackageName }).InstallLocation | Sort-Object -Descending | Select-Object -First 1 -ErrorAction Stop
+            $winGetLatestVersion = ((Get-AppxPackage -AllUsers | Where-Object { $_.Name -eq $winGetPackageName }).Version | ForEach-Object { [version]$_ } | Sort-Object -Descending | Select-Object -First 1 -ErrorAction Stop).ToString()
+            $winGetPath = (Get-AppxPackage -AllUsers | Where-Object { $_.Name -eq $winGetPackageName -and $_.Version -eq $winGetLatestVersion }).InstallLocation
         }
         catch {
             $testWinGetPathFail = $true


### PR DESCRIPTION
This PR includes two things I found during testing in our corp environment:

- We have multiuser machines, where sometimes many outdated versions of apps stick around, because previous users never log in again. In this case, the previous logic of just sorting all AppInstaller InstallLocations lexicographically descending does not lead to the desired result. Lexicographically, 1.4.3161.0 is higher than 1.21.2721.0. Version-wise, this is of course false.
- I found that the winget.exe list in Test-WinGetApp function is not working as expected, without explicitly setting the 'scope' to 'machine'. This fixes #10 